### PR TITLE
post-merge: drop Discord notification, fix Notify Maintainers API

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -140,14 +140,6 @@ jobs:
             git commit -m "Add ${{steps.parse_pr.outputs.title}}"
             git push
 
-      - name: Discord notification
-        if: steps.get_pr.outputs.pr_number != ''
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        uses: Ilshidur/action-discord@master
-        with:
-          args: "📢 The floppy image \"${{ steps.parse_pr.outputs.title }}\" (category: ${{ steps.parse_pr.outputs.category }}) has been successfully processed and added to the database. You can download the file from: http://ataristdb.sidecartridge.com/MISC/${{ steps.parse_pr.outputs.filename }}"
-
       - name: Notify Maintainers
         if: failure() && steps.get_pr.outputs.pr_number != ''
         uses: actions/github-script@v6
@@ -156,7 +148,7 @@ jobs:
             script: |
               const issueNumber = parseInt('${{ steps.get_pr.outputs.pr_number }}');
         
-              github.issues.createComment({
+              await github.rest.issues.createComment({
                 issue_number: issueNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
### What

- Remove the **Discord notification** step from `post-merge.yml`. Discord is no longer used, and its `DISCORD_WEBHOOK` secret now points to a deleted webhook, so every post-merge run failed at this step with `404 Unknown Webhook (code 10015)`.
- Fix the **Notify Maintainers** failure handler: it called `github.issues.createComment`, which does not exist in `actions/github-script@v6` (the REST client is exposed under `github.rest.issues`). This turned the failure handler itself into a second error (`Cannot read properties of undefined (reading 'createComment')`). Now uses `await github.rest.issues.createComment(...)`.

### Why

The actual submission processing (CRC32, DB update, S3 upload, index commit) already succeeds; only these two trailing steps were failing and painting successful runs red. Removing the dead Discord step makes a clean submission finish green, and the corrected handler will now post a real comment if a genuine processing error occurs.

### Notes

No change to the processing logic. The `DISCORD_WEBHOOK` secret can be deleted from repo settings.